### PR TITLE
Methyl summary col updates

### DIFF
--- a/sounDMR2/R/Sound_DMRv2.R
+++ b/sounDMR2/R/Sound_DMRv2.R
@@ -289,6 +289,11 @@ create_cols_for_individuals <- function(Exp_ID_Treated,
 #'
 #' @inheritParams create_cols_for_individuals
 #' @param dmr_obj the dmr object containing the experimental design and raw data
+#' @param treated the string representing the treated group
+#' @param additional_summary_cols a nested list of parameters to create additional
+#' summary columns. Each nested list will be a tuple where the first value is
+#' the summary stats function (e.g. sd, mean, var) and the second value is the
+#' string name of the column on which to run the summary statistic function
 #'
 #' @export
 create_methyl_summary <- function(dmr_obj, control = 'C', treated = 'T',


### PR DESCRIPTION
Added the option for a user to select a treatment group when running the create_methyl_summary function.

Also allowed the option for the user to include additional columns of summary stats to the end of the methyl_summary file.