### PR TITLE
Adding step4 wrapper

### DIFF
--- a/Docker/step4_sounDMRw.R
+++ b/Docker/step4_sounDMRw.R
@@ -87,7 +87,7 @@ process_subdir <- function(subdir) {
                              analysis_type = analysis_type)
   
   rm(dmrobj,methyl_summary)
-  write.csv(methyl_summary,paste(file_pre,"methyl_sum_DMR.csv", sep="_"), row.names = F)
+  write.csv(methyl_summary_DMR, paste(file_pre,"methyl_sum_DMR.csv", sep="_"), row.names = F)
 }
 lapply(subdirs, process_subdir)
 

--- a/Docker/step4_sounDMRw.R
+++ b/Docker/step4_sounDMRw.R
@@ -3,10 +3,15 @@
 suppressMessages(library(GetoptLong))
 suppressMessages(suppressWarnings(library(sounDMR)))
 
-control_value = 'C' 
-treated_value = 'T'
+control_value = 'Control' 
+treated_value = 'Treated'
 additional_sum_col = 'Group'
 stat = 'sd'
+reads_thresh = 3
+model_type = 'binomial'
+analysis_type = 'group'
+fixed_effect = 'Group'
+random_effect = 'Individual'
 
 spec = "
 This creates a dmr object and methyl syummary. the methyl summary will be saved in the directory.  
@@ -18,11 +23,23 @@ Options:
   <directory=s> Directory path for the methylframe/megaframe. Hint:chunks
   <Megaframe_pattern=s> Pattern of megaframe file.
   <exp_design=s> Input experimental design file. 
-  <control_value=s> Default is C. This takes in the variable for control in the additional summary column. For example if your Group is T vs C, then control column would be C and treated column will be T, additional_sum_col will be 'Group'
-  <treated_value=s> Default is T. This takes in the variable for control in the additional summary column.
-  <additional_sum_col=s> Default is Group. It could be Treatment, Group, Treatment type etc. based on the desig, change the column values accordingly
-  <stat=s>  Default is sd (standard deviation). Apart from mean, enter other types of statistic to obtain from the groups
-  <file_prefix=s> Add a prefix to files that are saved into the working directory while running the function.
+  <control_value> Default is C. This takes in the variable for control in the 
+  additional summary column. For example if your Group is T vs C, 
+  then control column would be C and treated column will be T, 
+  additional_sum_col will be 'Group'
+  <treated_value> Default is T. This takes in the variable for control in 
+  the additional summary column.
+  <additional_sum_col> Default is Group. It could be Treatment, Group, 
+  Treatment type etc. based on the desig, change the column values accordingly
+  <stat>  Default is sd (standard deviation). Apart from mean, 
+  enter other types of statistic to obtain from the groups
+  <reads_thresh> No. of reads that pass to be considered for the model.
+  <model_type> Default is Binomial. Takes in 'Binomial' or 'Beta-Binomial'.
+  <analysis_type> Default is Group. This can be 'Group' or 'Individual'.
+  <fixed_effect> Default is Group. Provide the column to run as fixed variable.
+  <random_effect> Default is Individual. Provide the column to run as Random variable.
+  <file_prefix=s> Add a prefix to files that are saved into 
+  the working directory while running the function.
   <verbose> print messages.
 
 Contact: name@address
@@ -55,14 +72,22 @@ process_subdir <- function(subdir) {
   #create dmrobj
   dmr_obj <- sounDMR::create_dmr_obj(Methylframe, experimental_design_df)
   #create methyl summary
-  methyl_summary <- soundMR::create_methyl_summary(dmr_obj, 
+  methyl_summary <- sounDMR::create_methyl_summary(dmr_obj, 
                                           control = control_value, 
                                           treated = treated_value,
                                           additional_summary_cols = list(
-                                            c(stat, additional_sum_col)))  
+                                            c(stat, additional_sum_col)))
   
-  write.csv(methyl_summary,paste(file_pre,"methyl_sum.csv", sep="_"), row.names = F)
+  #saveRDS(dmr_obj, file=paste(file_pre,"dmr_obj", sep="_"))
+  #write.csv(methyl_summary,paste(file_pre,"methyl_sum.csv", sep="_"), row.names = F)
+  # Run the Group DMR analysis
+  methyl_summary_DMR <- find_DMR(methyl_summary, dmr_obj, fixed = c(fixed_effect), 
+                             random = random_effect, reads_threshold = reads_thresh, 
+                             control = control_value, model = model_type, 
+                             analysis_type = analysis_type)
+  
   rm(dmrobj,methyl_summary)
+  write.csv(methyl_summary,paste(file_pre,"methyl_sum_DMR.csv", sep="_"), row.names = F)
 }
 lapply(subdirs, process_subdir)
 

--- a/Docker/step4_sounDMRw.R
+++ b/Docker/step4_sounDMRw.R
@@ -3,8 +3,8 @@
 suppressMessages(library(GetoptLong))
 suppressMessages(suppressWarnings(library(sounDMR)))
 
-control_value = 'Control' 
-treated_value = 'Treated'
+control_value = 'C' 
+treated_value = 'T'
 additional_sum_col = 'Group'
 stat = 'sd'
 reads_thresh = 3


### PR DESCRIPTION
Things to note: 
Based on our discussions: The script follows option 1, where create_dmr_obj(), create_methyl_summary() and find_DMR() are part of the same wrapper and hence will be in the same batch job. 
Because of 3 functions, it is encoded with a laundry list of input parameters, some of which are default. 